### PR TITLE
[FEAT]: Dockerize environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Python 3.8 as base image (known to work well with Nunavut 0.4.0)
+FROM python:3.8-slim
+
+# Install git and required build tools
+RUN apt-get update && apt-get install -y \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install nunavut==2.3.1
+
+# Set working directory
+WORKDIR /app
+
+# Clone the public regulated data types
+RUN git clone https://github.com/UAVCAN/public_regulated_data_types.git
+
+# Default to bash so we can run commands interactively
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ Public unregulated vendor-specific UAVCAN DSDL definitions
 
 # UAVCAN DSDL Compilation with Nunavut
 
-This README provides guidance on how to create a new UAVCAN message and compile it using Nunavut.
+This README provides guidance on how to create a new UAVCAN message and compile it using Nunavut via Docker.
 
 ## Prerequisites
 
-- Python installed on your system
-- Nunavut installed (you can install it using `pip install nunavut`)
-- Clone or download the UAVCAN public regulated data types from [here](https://github.com/UAVCAN/public_regulated_data_types)
+- Docker Engine installed on your system
 
 ## Creating a New Message
 
@@ -19,36 +17,60 @@ This README provides guidance on how to create a new UAVCAN message and compile 
 2. **Define Your Message**: Open the file in a text editor and define your message. Follow the UAVCAN specification for DSDL. An example message definition might look like:
 
     `uint8 MY_CONSTANT = 42`
-`uint32 value`
-`uint32 result`
-
+    `uint32 value`
+    `uint32 result`
 
 3. **Save Your File**: Save the changes to your DSDL file.
 
 ## Compiling the Message
 
-1. **Open Command Line**: Open your command line interface.
+1. **Configure Input Variables**: Open `compile.sh` and modify these variables according to your setup:
+   ```bash
+   DSDL_INPUT_DIR="./path/to/your/dsdl/directory"  # Path to your .uavcan/.dsdl files
+   DSDL_OUTPUT_DIR="./nunavut_out"            # Where generated files will be saved
+   ```
 
-2. **Navigate to Your Project Directory**: Use the `cd` command to navigate to your project directory.
+2. **Run the Compilation Script**: Execute the compilation script:
+   ```bash
+   ./compile.sh
+   ```
 
-3. **Check Nunavut version**: The current supported version is `0.4.0`, you can find the exe in `nnvg.zip` 
-   
-4. **Run Nunavut**: Compile your DSDL file using the following command:
+3. **Check Results**: If compilation is successful, you'll see a message indicating where the output files are saved. If there's an error, the script will exit with an error message.
 
-```bash
-nnvg --target-language c --outdir .\nunavut_out\ -I [PATH TO public_regulated_data_types\uavcan] .\kiwibot --allow-unregulated-fixed-port-id
-```
-
-Replace `[PATH TO public_regulated_data_types\uavcan]` with the path to your UAVCAN public regulated data types directory.
-Replace `.\kiwibot` with the path to your project's DSDL directory.
-Check for Output: After running the command, check the `.\nunavut_out directory` for the generated source files.
-
+## Output
+- Generated files will be placed in the directory specified by `DSDL_OUTPUT_DIR`
+- The script will confirm successful compilation with a message showing the output location
 
 ## Integration
 Integrate the generated source code into your project.
 Ensure that your project's build system includes the generated files.
 
 ## Troubleshooting
-If you encounter errors, verify the syntax of your DSDL file and the paths in your Nunavut command.
-Ensure all dependencies and standard DSDL definitions are correctly referenced.
+- Ensure Docker Engine is running
+- Verify the paths in `DSDL_INPUT_DIR` and `DSDL_OUTPUT_DIR` are correct
+- Check that your DSDL file follows the UAVCAN specification
+- If you encounter errors, verify the syntax of your DSDL file and the paths in the `compile.sh` script.
+
 For more information, refer to the UAVCAN specification and the Nunavut documentation.
+
+## Common Errors and Solutions
+
+### Missing Serialization Mode Error
+If you encounter an error like this:
+
+```MissingSerializationModeError: Either @sealed or @extent ... are required```
+
+**Solution**: Add the following line at the end of your DSDL file:
+
+```
+... {your dsdl file content} ...
+
+@extent 64 * 8
+```
+
+**Why this works**: 
+- In UAVCAN, every message type must declare its serialization mode
+- `@extent` defines the maximum allowed serialized length of the message in bits
+- `64 * 8` means 64 bytes (512 bits), which is typically sufficient for most messages
+- This helps ensure wire compatibility and prevents undefined behavior in message serialization
+- Alternative to `@extent` is `@sealed`, which makes the message type immutable but less flexible for future changes

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,32 @@
+mkdir -p ./nunavut_out
+
+# Build Docker image
+echo "Building Docker image..."
+docker build -t kiwibot-dsdl-test .
+
+# DSDL compilation configuration
+compile_dsdl_cmd="nnvg \
+    --target-language c \
+    --outdir /app/output \
+    -I ./public_regulated_data_types/uavcan \
+    /app/dsdl_input \
+    --allow-unregulated-fixed-port-id"
+
+DSDL_INPUT_DIR="./kiwibot/test" # Define input directory with .uavcan/.dsdl files to compile
+COMPILED_OUTPUT_DIR="./nunavut_out" # Define output directory to save compiled files
+
+# Get current user's UID and GID
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+
+# Run compilation cmd inside docker container with user permissions
+if docker run \
+    --user ${USER_ID}:${GROUP_ID} \
+    -v ${COMPILED_OUTPUT_DIR}:/app/output \
+    -v ${DSDL_INPUT_DIR}:/app/dsdl_input \
+    kiwibot-dsdl-test $compile_dsdl_cmd; then
+    echo "Compilation complete. Output files saved in ${COMPILED_OUTPUT_DIR}"
+else
+    echo "Error: Docker compilation failed"
+    exit 1
+fi


### PR DESCRIPTION
# Dockerize Development Environment

## Overview
Added Docker support to streamline development setup and ensure consistent environments

## Changes
- Added `Dockerfile` for creating containerized development environment
- Added `compile.sh` to generate files from dsdl in a simpler manner
- Updated documentation with Docker setup instructions

## Benefits
- Consistent development environment
- Simplified onboarding process

## Setup Instructions
1. Install Docker engine

## Notes
- This has been tested only on Ubuntu 22.04 (jammy)